### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # `gcr.io/paketo-buildpacks/adoptium`
 
-The Paketo Adoptium Buildpack is a Cloud Native Buildpack that provides the Adoptium implementations of JREs and JDKs.
+The Paketo Buildpack for Adoptium is a Cloud Native Buildpack that provides the Adoptium implementations of JREs and JDKs.
 
 This buildpack is designed to work in collaboration with other buildpacks which request contributions of JREs and JDKs.
 
-The Paketo Adoptium Buildpack is the successor to the Paketo AdoptOpenJDK Buildpack. This change is to keep the Paketo buildpacks in sync with [changes to the upstream project](https://adoptium.net/faq.html#AdoptOpenJDK).
+The Paketo Buildpack for Adoptium is the successor to the Paketo Buildpack for AdoptOpenJDK. This change is to keep the Paketo buildpacks in sync with [changes to the upstream project](https://adoptium.net/faq.html#AdoptOpenJDK).
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/adoptium"
   id = "paketo-buildpacks/adoptium"
   keywords = ["java", "jvm", "jre", "jdk"]
-  name = "Paketo Adoptium Buildpack"
+  name = "Paketo Buildpack for Adoptium"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Adoptium Buildpack' to 'Paketo Buildpack for Adoptium'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
